### PR TITLE
Force convert video file to mp3 file

### DIFF
--- a/class/Downloader.php
+++ b/class/Downloader.php
@@ -197,7 +197,7 @@ class Downloader
 
 		if($this->audio_only)
 		{
-			$cmd .= " -x ";
+			$cmd .= " --extract-audio --audio-format mp3 ";
 		}
 
 		foreach($this->urls as $url)


### PR DESCRIPTION
Hello,
Ii try to use this script but when try to download audio only, it extract audio to ".m4a" file.
I'm not sure is this bug or feature but i think more convenient is mp3 and as fare i remember youtube-dl make some changes about extracting audio so this commit make sure youtube-dl extract mp3 file "for download".
 
I tested on: 
youtube-dl --version
2015.11.02

regards