### PR TITLE
Add webm to the video extentions

### DIFF
--- a/class/FileHandler.php
+++ b/class/FileHandler.php
@@ -3,7 +3,7 @@
 class FileHandler
 {
 	private $config = [];
-	private $videos_ext = ".{avi,mp4,flv}";
+	private $videos_ext = ".{avi,mp4,flv,webm}";
 	private $musics_ext = ".{mp3,ogg,m4a}";
 
 	public function __construct()


### PR DESCRIPTION
Youtube-dl sometimes consider the best format to be webm format and it downloads it by default. And it didn't get listed because it is not considered a video extension.