### PR TITLE
Added option to download files indirectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ It supports simultaneous downloads in background.
 2. Set security to true
 3. Find a password, hash it with md5 and replace the value of password.
 
+## Troubleshooting
+1. If you don't want a password set `security` to false
+2. If you have problems downloading files, check the permissions and try setting `indirect_download` to true
+
 Example (chosen password is root):
 
 ```

--- a/class/Session.php
+++ b/class/Session.php
@@ -2,7 +2,7 @@
 
 class Session
 {
-	private $config = [];
+	public $config = [];
 
 	private static $_instance;
 

--- a/config/config.php
+++ b/config/config.php
@@ -8,6 +8,7 @@ return array(
 	"password" => "63a9f0ea7bb98050796b649e85481845",
 	"outputFolder" => "downloads",
 	"extracter" => "avconv",
+	"indirect_download" => false,
 	"max_dl" => 3);
 
 ?>

--- a/getfile.php
+++ b/getfile.php
@@ -1,0 +1,31 @@
+<?php
+	require_once 'class/Session.php';
+	require_once 'class/FileHandler.php';
+
+	$session = Session::getInstance();
+	$file = new FileHandler;
+
+	if(!$session->is_logged_in())
+	{
+		header("Location: login.php");
+	}
+
+	$filename = $_GET['file'];
+    
+	if (strpos($filename, DIRECTORY_SEPARATOR) !== false || empty($filename)) 
+	{
+		die("Invalid parameter 'file'");
+	}
+    
+	$path = $file->get_downloads_folder() . DIRECTORY_SEPARATOR . $filename;
+    
+	$fp = fopen($path, 'rb');
+
+	header("Content-Type: application/octet-stream");
+	header('Content-Disposition: attachment; filename="' . $filename . '"');
+	header("Content-Length: " . filesize($path));
+
+
+	fpassthru($fp);
+
+	exit;

--- a/list.php
+++ b/list.php
@@ -56,7 +56,14 @@
 				foreach($files as $f)
 				{
 					echo "<tr>";
-					echo "<td><a href=\"".$file->get_downloads_folder().'/'.$f["name"]."\" download>".$f["name"]."</a></td>";
+					if ($session->config["indirect_download"])
+					{
+						echo "<td><a href=\"getfile.php?file=".urlencode($f["name"])."\" download>".$f["name"]."</a></td>";
+					} 
+					else 
+					{
+						echo "<td><a href=\"".$file->get_downloads_folder().'/'.$f["name"]."\" download>".$f["name"]."</a></td>";
+					}
 					echo "<td>".$f["size"]."</td>";
 					echo "<td><a href=\"./list.php?delete=$i&type=$t\" class=\"btn btn-danger btn-sm\">Delete</a></td>";
 					echo "</tr>";


### PR DESCRIPTION
This adds an option to the config.php file to download videos and music via an getfile.php script.
(that simply checks if te file is valid and then `fpassthru`'s it's content)

This fixes the problem where files can't be downloaded because the script is in a subfolder or the download directory is not visible to the outside (I download my stuff to `/tmp/yt-downloader/`)

fixes #43 
fixes #38 

I left the option default-off, so it doesn't break possible existing setups

Regards
 ~ Mike